### PR TITLE
Remove two warnings

### DIFF
--- a/src/Reflex/Dynamic/TH.hs
+++ b/src/Reflex/Dynamic/TH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeOperators, GADTs, EmptyDataDecls #-}
+{-# LANGUAGE TemplateHaskell, ScopedTypeVariables, TypeOperators, GADTs, EmptyDataDecls, PatternGuards #-}
 module Reflex.Dynamic.TH (qDyn, unqDyn) where
 
 import Reflex.Dynamic

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -13,7 +13,9 @@ import Data.Traversable
 import Control.Monad hiding (mapM, mapM_, forM_, forM, sequence)
 import Control.Monad.Reader hiding (mapM, mapM_, forM_, forM, sequence)
 import GHC.Exts
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
+#endif
 import Data.Dependent.Map (DMap, DSum (..))
 import qualified Data.Dependent.Map as DMap
 import Data.GADT.Compare


### PR DESCRIPTION
Should be pretty obvious. As you are using `-Wall` it seems like a good idea to get rid of the warnings where possible.