### PR TITLE
Improvements for ReflexHost

### DIFF
--- a/src/Reflex/Host/Class.hs
+++ b/src/Reflex/Host/Class.hs
@@ -5,7 +5,7 @@ import Prelude hiding (mapM, mapM_, sequence, sequence_, foldl)
 
 import Reflex.Class
 
-import Control.Monad.Trans.Class
+import Control.Monad.Trans
 import Control.Monad.Reader (ReaderT())
 import Control.Monad.Writer (WriterT())
 import Control.Monad.Cont   (ContT())

--- a/src/Reflex/Host/Class.hs
+++ b/src/Reflex/Host/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification, GADTs, ScopedTypeVariables, TypeFamilies, FlexibleInstances, MultiParamTypeClasses, GeneralizedNewtypeDeriving, RankNTypes, BangPatterns, UndecidableInstances, EmptyDataDecls, RecursiveDo, RoleAnnotations, FunctionalDependencies #-}
+{-# LANGUAGE ExistentialQuantification, GADTs, ScopedTypeVariables, TypeFamilies, FlexibleInstances, MultiParamTypeClasses, GeneralizedNewtypeDeriving, RankNTypes, BangPatterns, UndecidableInstances, EmptyDataDecls, RecursiveDo, RoleAnnotations, FunctionalDependencies, FlexibleContexts #-}
 module Reflex.Host.Class where
 
 import Prelude hiding (mapM, mapM_, sequence, sequence_, foldl)
@@ -15,35 +15,86 @@ import Control.Monad.State  (StateT())
 import Data.Dependent.Sum (DSum)
 import Control.Monad.Ref
 
-class Reflex t => ReflexHost t where
+-- | Framework implementation support class for the reflex implementation represented by @t@.
+class (Reflex t, MonadReflexCreateTrigger t (HostFrame t), MonadSample t (HostFrame t), MonadHold t (HostFrame t)) => ReflexHost t where
   type EventTrigger t :: * -> *
   type EventHandle t :: * -> *
   type HostFrame t :: * -> *
 
+-- | Monad that allows to read events' values.
 class (ReflexHost t, Monad m) => MonadReadEvent t m | m -> t where
+  -- | Read the value of an 'Event' from an 'EventHandle' (created by calling 'subscribeEvent').
+  --
+  -- After event propagation is done, all events can be in two states: either they are firing with some value or they are not firing.
+  -- In the former case, this function returns @Just act@, where @act@ in an action to read the current value of
+  -- the event. In the latter case, the function returns @Nothing@.
+  --
+  -- This function is normally used in the calllback for 'fireEventsAndRead'.
   readEvent :: EventHandle t a -> m (Maybe (m a))
 
-class (Monad m, ReflexHost t) => MonadReflexCreateTrigger t m | m -> t where
-  -- | Creates an original Event (one that is not based on any other event).
+-- | A monad where new events feed from external sources can be created.
+class Monad m => MonadReflexCreateTrigger t m | m -> t where
+  -- | Creates a root 'Event' (one that is not based on any other event).
+  --
   -- When a subscriber first subscribes to an event (building another event
-  -- that depends on the subscription) the given callback function is run by
-  -- passing a trigger. The event is then set up in IO. The callback
-  -- function returns an accompanying teardown action.
+  -- that depends on the subscription) the given callback function is run and
+  -- passed a trigger. The callback function can then set up the event source in IO.
+  -- After this is done, the callback function must return an accompanying teardown action.
+  --
   -- Any time between setup and teardown the trigger can be used to fire
-  -- the event.
+  -- the event, by passing it to 'fireEventsAndRead'.
+  --
+  -- Note: An event may be set up multiple times. So after the teardown action is executed, the event may still be set up again in the future.
   newEventWithTrigger :: (EventTrigger t a -> IO (IO ())) -> m (Event t a)
 
 class (Monad m, ReflexHost t, MonadReflexCreateTrigger t m) => MonadReflexHost t m | m -> t where
+  -- | Propagate some events firings and read the values of events afterwards.
+  --
+  -- This function will create a new frame to fire the given events. It will then update all
+  -- dependent events and behaviors. After that is done, the given callback is executed which
+  -- allows to read the final values of events and check whether they have fired in this frame or
+  -- not.
+  --
+  -- All events that are given are fired at the same time.
+  --
+  -- This function is typically used in the main loop of a reflex framework implementation.
+  -- The main loop waits for external events to happen (such as keyboard input or a mouse click)
+  -- and then fires the corresponding events using this function. The read callback can be used
+  -- to read output events and perform a corresponding response action to the external event.
   fireEventsAndRead :: [DSum (EventTrigger t)] -> (forall m'. (MonadReadEvent t m') => m' a) -> m a
-  subscribeEvent :: Event t a -> m (EventHandle t a) --TODO: Return a handle, and use them in fireEventsAnRead
 
+  -- | Subscribe to an event and set it up if needed.
+  --
+  -- This function will create a new 'EventHandle' from an 'Event'. This handle may then be used via
+  -- 'readEvent' in the read callback of 'fireEventsAndRead'.
+  --
+  -- If the event wasn't subscribed to before (either manually or through a dependent event or behavior)
+  -- then this function will cause the event and all dependencies of this event to be set up.
+  -- For example, if the event was created by 'newEventWithTrigger', then it's callback will be executed.
+  --
+  -- It's safe to call this function multiple times.
+  subscribeEvent :: Event t a -> m (EventHandle t a)
+
+  -- | Run a frame without any events firing.
+  --
+  -- This function should be used when you want to use 'sample' and 'hold' when no events are currently firing.
+  -- Using this function in that case can improve performance, since the implementation can assume that no events
+  -- are firing when 'sample' or 'hold' are called.
+  --
+  -- This function is commonly used to set up the basic event network when the application starts up.
   runHostFrame :: HostFrame t a -> m a
 
+-- | Like 'fireEventsAndRead', but without reading any events.
 fireEvents :: MonadReflexHost t m => [DSum (EventTrigger t)] -> m ()
-{-# INLINE fireEvents #-}
 fireEvents dm = fireEventsAndRead dm $ return ()
+{-# INLINE fireEvents #-}
 
-{-# INLINE newEventWithTriggerRef #-}
+-- | Create a new event and store its trigger in an 'IORef' while it's active.
+--
+-- An event is only active between the set up (when it's first subscribed to) and the teardown phases (when noboby is subscribing the event anymore).
+-- This function returns an Event and an 'IORef'. As long as the event is active, the 'IORef' will contain 'Just' the event trigger to
+-- trigger this event. When the event is not active, the 'IORef' will contain 'Nothing'. This allows event sources to be more efficient,
+-- since they don't need to produce events when nobody is listening.
 newEventWithTriggerRef :: (MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref IO) => m (Event t a, Ref m (Maybe (EventTrigger t a)))
 newEventWithTriggerRef = do
   rt <- newRef Nothing
@@ -51,6 +102,7 @@ newEventWithTriggerRef = do
     writeRef rt $ Just t
     return $ writeRef rt Nothing
   return (e, rt)
+{-# INLINE newEventWithTriggerRef #-}
 
 --------------------------------------------------------------------------------
 -- Instances

--- a/src/Reflex/Host/Class.hs
+++ b/src/Reflex/Host/Class.hs
@@ -5,6 +5,7 @@ import Prelude hiding (mapM, mapM_, sequence, sequence_, foldl)
 
 import Reflex.Class
 
+import Control.Monad.Fix
 import Control.Monad.Trans
 import Control.Monad.Reader (ReaderT())
 import Control.Monad.Writer (WriterT())
@@ -16,7 +17,7 @@ import Data.Dependent.Sum (DSum)
 import Control.Monad.Ref
 
 -- | Framework implementation support class for the reflex implementation represented by @t@.
-class (Reflex t, MonadReflexCreateTrigger t (HostFrame t), MonadSample t (HostFrame t), MonadHold t (HostFrame t)) => ReflexHost t where
+class (Reflex t, MonadReflexCreateTrigger t (HostFrame t), MonadSample t (HostFrame t), MonadHold t (HostFrame t), MonadFix (HostFrame t)) => ReflexHost t where
   type EventTrigger t :: * -> *
   type EventHandle t :: * -> *
   type HostFrame t :: * -> *

--- a/src/Reflex/Spider/Internal.hs
+++ b/src/Reflex/Spider/Internal.hs
@@ -1380,7 +1380,6 @@ instance R.MonadReflexHost Spider SpiderHost where
   subscribeEvent e = SpiderHost $ do
     _ <- runFrame $ getEventSubscribed $ unSpiderEvent e --TODO: The result of this should actually be used
     return $ SpiderEventHandle (unSpiderEvent e)
-  runFrame = SpiderHost . runFrame
   runHostFrame = SpiderHost . runFrame . runSpiderHostFrame
 
 instance MonadRef SpiderHost where


### PR DESCRIPTION
This PR adds missing superclasses, docs for all functions in the Reflex.Host.Class 
module and some missing instances for mtl transformer types.