### PR TITLE
Add link to reflex hackage package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ Comprehensive documentation is still a work in progress, but a tutorial for Refl
 
 [reddit/r/reflexfrp](http://www.reddit.com/r/reflexfrp)
 
+[reflex at hackage](https://hackage.haskell.org/package/reflex)
+
 irc.freenode.net #reflex-frp


### PR DESCRIPTION
I thought it might be nice to have a link to the hackage package. Especially since it contains API documentation.