### PR TITLE
add combineDyn3 and combineDyn4

### DIFF
--- a/reflex.cabal
+++ b/reflex.cabal
@@ -39,6 +39,7 @@ library
     Reflex.Spider.Internal,
     Reflex.Class,
     Reflex.Dynamic,
+    Reflex.Dynamic.Combinators,
     Reflex.Dynamic.TH,
     Reflex.Host.Class,
     Data.Functor.Misc

--- a/src/Reflex.hs
+++ b/src/Reflex.hs
@@ -1,10 +1,12 @@
 module Reflex ( module Reflex.Class
               , module Reflex.Dynamic
+              , module Reflex.Dynamic.Combinators
               , module Reflex.Dynamic.TH
               , module Reflex.Spider
               ) where
 
 import Reflex.Class
 import Reflex.Dynamic
+import Reflex.Dynamic.Combinators
 import Reflex.Dynamic.TH
 import Reflex.Spider

--- a/src/Reflex/Dynamic/Combinators.hs
+++ b/src/Reflex/Dynamic/Combinators.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE QuasiQuotes, GADTs #-}
+module Reflex.Dynamic.Combinators ( combineDyn3
+                                  , combineDyn4
+                                  ) where
+
+import Reflex.Class
+import Reflex.Dynamic
+import Reflex.Dynamic.TH
+
+-- | combineDyn for three 'Dynamic's.
+combineDyn3 :: (Reflex t, MonadHold t m)
+  => (a -> b -> c -> d)
+  -> Dynamic t a
+  -> Dynamic t b
+  -> Dynamic t c
+  -> m (Dynamic t d)
+combineDyn3 f a b c = [mkDyn|f $a $b $c|]
+
+-- | combineDyn for four 'Dynamic's.
+combineDyn4 :: (Reflex t, MonadHold t m)
+  => (a -> b -> c -> d -> e)
+  -> Dynamic t a
+  -> Dynamic t b
+  -> Dynamic t c
+  -> Dynamic t d
+  -> m (Dynamic t e)
+combineDyn4 f a b c d = [mkDyn|f $a $b $c $d|]
+
+


### PR DESCRIPTION
I'm putting this here for consideration.

I find that sometimes I need a `Dynamic` that is derived from 3 or more other `Dynamic`s.

`mkDyn` is very flexible itself so one may want to just use it directly and it seems having `combineDynN` explicitly defined adds little value. Also stopping at 4 is totally arbitrary - it's just that currently I don't have a use case for more.

Cons:
* cannot add to `Reflex.Dynamic` - would cause circular imports between `Reflex.Dynamic` and `Reflex.Dynamic.TH`
* will add to library compilation time with ghcjs

Pros:
* nicer syntax - don't have to explicitly use TH
* if the pattern turns out to be common enough it can save lots of compilation time by shifting the TH burden to the library - using `mkDyn` adds a good couple seconds on each compile for my test project

It depends on how often do people currently need to chain `combineDyn`s. Eg. `combineDyn (,) da db >>= combineDyn f dc` could be replaced by `combineDyn3 g da db dc` without affecting compilation time.

So main question: would anyone else find it useful?