### PR TITLE
Change the variable name used when generating mkDyn expressions to something far less likely to capture.

### DIFF
--- a/src/Reflex/Dynamic/TH.hs
+++ b/src/Reflex/Dynamic/TH.hs
@@ -22,7 +22,7 @@ qDyn qe = do
         Just (Refl :: d :~: Exp)
           | AppE (VarE m) eInner <- d
           , m == 'unqMarker
-          -> do n <- lift $ newName "dyn"
+          -> do n <- lift $ newName "dynamicQuotedExpressionVariable"
                 modify ((n, eInner):)
                 return $ VarE n
         _ -> gmapM f d


### PR DESCRIPTION
I don't know if Template Haskell has a better solution to this problem, but this at least keeps people from
stumbling over dyn.